### PR TITLE
removed route to my old landing page, and redirected root to the index page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  root to: 'pages#home'
+  root to: 'cats#index'
 
   resources :cats, only: [:index, :show]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
So now people go to 9lives.com, and gets redirected to the index page. 

![bilde](https://user-images.githubusercontent.com/63665667/92301536-f71f1980-ef64-11ea-8f7e-329a4fa84231.png)
